### PR TITLE
Adds correct command arguments #12

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Run the following command to load the package files for Mariner App:
 > if using the arches-containers, run this in the application container
 
 ```bash
-python manage.py packages -o load_package -s '/path/to/mariner_app/mariner_app/pkg/'
+python manage.py packages -o load_package -a mariner_app
 ```
 
 ## License


### PR DESCRIPTION
This pull request makes a small update to the `README.md` instructions for loading package files for the Mariner App. The change simplifies the command to use the `-a mariner_app` argument instead of specifying the full path.

This is not documented, but what the `-a` flag does can be found here:

https://github.com/archesproject/arches/blob/dev/7.6.x/arches/management/commands/packages.py#L450:L457