### PR TITLE
Release/1.0.x -> Release/1.1.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Run the following command to load the package files for Mariner App:
 > if using the arches-containers, run this in the application container
 
 ```bash
-python manage.py packages -o load_package -s '/path/to/mariner_app/mariner_app/pkg/'
+python manage.py packages -o load_package -a mariner_app
 ```
 
 ## License


### PR DESCRIPTION
This pull request updates the documentation for loading package files in the Mariner App. The change simplifies the command by replacing the source path argument with a package name argument.

- **Documentation update:**
  * In `README.md`, the example command for loading package files was updated to use the `-a mariner_app` argument instead of specifying a source path with `-s`.