### PR TITLE
AB#99248 Fix issue of check failing due to file name collisions - attempt 2

### DIFF
--- a/.github/actions/build-and-test-branch/action.yml
+++ b/.github/actions/build-and-test-branch/action.yml
@@ -13,7 +13,7 @@ inputs:
     description: 'Python version for matrix; used to control artifact uploads'
     required: false
   coverage-python-version:
-    description: 'Python version to upload coverage artifacts for'
+    description: 'Python version that uploads coverage artifacts'
     required: false
     default: '3.12'
 runs:

--- a/.github/actions/build-and-test-branch/action.yml
+++ b/.github/actions/build-and-test-branch/action.yml
@@ -12,6 +12,10 @@ inputs:
   python-version:
     description: 'Python version for matrix; used to control artifact uploads'
     required: false
+  coverage-python-version:
+    description: 'Python version to upload coverage artifacts for'
+    required: false
+    default: '3.12'
 runs:
   using: 'composite'
   steps:
@@ -98,7 +102,7 @@ runs:
       shell: bash
 
     - name: Upload frontend coverage report as artifact
-      if: ${{ inputs.python-version == '3.12' || inputs.python-version == '' }}
+      if: ${{ inputs.python-version == inputs.coverage-python-version }}
       uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.branch-type }}-branch-frontend-coverage-report-py${{ inputs.python-version }}
@@ -106,7 +110,7 @@ runs:
         overwrite: true
 
     - name: Upload Python coverage report as artifact
-      if: ${{ inputs.python-version == '3.12' || inputs.python-version == '' }}
+      if: ${{ inputs.python-version == inputs.coverage-python-version }}
       uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.branch-type }}-branch-python-coverage-report-py${{ inputs.python-version }}

--- a/.github/actions/build-and-test-branch/action.yml
+++ b/.github/actions/build-and-test-branch/action.yml
@@ -72,7 +72,7 @@ runs:
     - name: Run frontend tests
       run: |
         npm run vitest
-        mv coverage/frontend/coverage.xml ${{ inputs.branch-type }}_branch_frontend_coverage.xml
+        mv coverage/frontend/coverage.xml ${{ inputs.branch-type }}_branch_frontend_coverage_py${{ inputs.python-version }}.xml
       shell: bash
 
     - name: Check for missing migrations
@@ -94,21 +94,21 @@ runs:
       run: |
         coverage report
         coverage json
-        mv coverage/python/coverage.json ${{ inputs.branch-type }}_branch_python_coverage.json
+        mv coverage/python/coverage.json ${{ inputs.branch-type }}_branch_python_coverage_py${{ inputs.python-version }}.json
       shell: bash
 
     - name: Upload frontend coverage report as artifact
       if: ${{ inputs.python-version == '3.12' || inputs.python-version == '' }}
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ inputs.branch-type }}-branch-frontend-coverage-report
-        path: ${{ inputs.branch-type }}_branch_frontend_coverage.xml
+        name: ${{ inputs.branch-type }}-branch-frontend-coverage-report-py${{ inputs.python-version }}
+        path: ${{ inputs.branch-type }}_branch_frontend_coverage_py${{ inputs.python-version }}.xml
         overwrite: true
 
     - name: Upload Python coverage report as artifact
       if: ${{ inputs.python-version == '3.12' || inputs.python-version == '' }}
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ inputs.branch-type }}-branch-python-coverage-report
-        path: ${{ inputs.branch-type }}_branch_python_coverage.json
+        name: ${{ inputs.branch-type }}-branch-python-coverage-report-py${{ inputs.python-version }}
+        path: ${{ inputs.branch-type }}_branch_python_coverage_py${{ inputs.python-version }}.json
         overwrite: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,6 +93,8 @@ jobs:
   check_frontend_coverage:
     runs-on: ubuntu-latest
     needs: [build_feature_branch, build_target_branch]
+    env:
+      PYTHON_VERSION: '3.12'
     steps:
       - uses: actions/checkout@v4
 
@@ -105,13 +107,13 @@ jobs:
       - name: Download feature branch frontend coverage report artifact
         uses: actions/download-artifact@v4
         with:
-          name: feature-branch-frontend-coverage-report
+          name: feature-branch-frontend-coverage-report-py${{ env.PYTHON_VERSION }}
           path: .
 
       - name: Extract feature branch frontend coverage data
         shell: pwsh
         run: |
-          [xml]$xml = Get-Content feature_branch_frontend_coverage.xml
+          [xml]$xml = Get-Content feature_branch_frontend_coverage_py${{ env.PYTHON_VERSION }}.xml
           $metrics = $xml.coverage.project.metrics
 
           $statements = [double]$metrics.statements
@@ -160,12 +162,12 @@ jobs:
         continue-on-error: true
         uses: actions/download-artifact@v4
         with:
-          name: target-branch-frontend-coverage-report
+          name: target-branch-frontend-coverage-report-py${{ env.PYTHON_VERSION }}
           path: .
 
       - name: Check if target branch frontend coverage report artifact exists
         run: |
-          if [ -f target_branch_frontend_coverage.xml ]; then
+          if [ -f target_branch_frontend_coverage_py${{ env.PYTHON_VERSION }}.xml ]; then
             echo "target_branch_frontend_coverage_artifact_exists=true" >> $GITHUB_ENV
           else
             echo "Target branch coverage not found. Defaulting to 0% coverage."
@@ -176,7 +178,7 @@ jobs:
         if: ${{ env.target_branch_frontend_coverage_artifact_exists == 'true' }}
         shell: pwsh
         run: |
-          [xml]$xml = Get-Content target_branch_frontend_coverage.xml
+          [xml]$xml = Get-Content target_branch_frontend_coverage_py${{ env.PYTHON_VERSION }}.xml
           $metrics = $xml.coverage.project.metrics
 
           $statements = [double]$metrics.statements
@@ -238,6 +240,8 @@ jobs:
   check_python_coverage:
     runs-on: ubuntu-latest
     needs: [build_feature_branch, build_target_branch]
+    env:
+      PYTHON_VERSION: '3.12'
     steps:
       - uses: actions/checkout@v4
 
@@ -250,20 +254,20 @@ jobs:
       - name: Download feature branch Python coverage report artifact
         uses: actions/download-artifact@v4
         with:
-          name: feature-branch-python-coverage-report
+          name: feature-branch-python-coverage-report-py${{ env.PYTHON_VERSION }}
           path: .
 
       - name: Download target branch Python coverage report artifact
         uses: actions/download-artifact@v4
         with:
-          name: target-branch-python-coverage-report
+          name: target-branch-python-coverage-report-py${{ env.PYTHON_VERSION }}
           path: .
 
       - name: Compare Python feature coverage with target coverage
         if: github.event_name == 'pull_request'
         run: |
-          feature_branch_python_coverage=$(cat feature_branch_python_coverage.json | grep -o '"totals": {[^}]*' | grep -o '"percent_covered": [0-9.]*' | awk -F ': ' '{print $2}')
-          target_branch_python_coverage=$(cat target_branch_python_coverage.json | grep -o '"totals": {[^}]*' | grep -o '"percent_covered": [0-9.]*' | awk -F ': ' '{print $2}')
+          feature_branch_python_coverage=$(cat feature_branch_python_coverage_py${{ env.PYTHON_VERSION }}.json | grep -o '"totals": {[^}]*' | grep -o '"percent_covered": [0-9.]*' | awk -F ': ' '{print $2}')
+          target_branch_python_coverage=$(cat target_branch_python_coverage_py${{ env.PYTHON_VERSION }}.json | grep -o '"totals": {[^}]*' | grep -o '"percent_covered": [0-9.]*' | awk -F ': ' '{print $2}')
 
           # Compare feature coverage with target coverage using floating-point comparison
           if awk -v feature="$feature_branch_python_coverage" -v target="$target_branch_python_coverage" 'BEGIN { exit (feature < target) ? 0 : 1 }'; then

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,6 +47,7 @@ jobs:
           project-name: 'mariner_app'
           branch-type: 'target'
           python-version: ${{ matrix.python-version }}
+          coverage-python-version: '3.12'
 
   build_feature_branch:
     runs-on: ubuntu-latest
@@ -89,6 +90,7 @@ jobs:
           project-name: 'mariner_app'
           branch-type: 'feature'
           python-version: ${{ matrix.python-version }}
+          coverage-python-version: '3.12'
 
   check_frontend_coverage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Update coverage report filenames to include Python version in CI workflow.

An alternative to #18 that reduces the amount of refactoring

This pull request updates the GitHub Actions workflows to make coverage report artifacts Python-version-specific. This helps prevent conflicts and ensures clarity when running tests with different Python versions. The changes update artifact names and file paths to include the Python version, and set the Python version as an environment variable in relevant jobs.

Key changes:

**Artifact naming and file handling:**

* Updated the naming convention for frontend and Python coverage report artifacts and files to include the Python version (e.g., `*_coverage_py3.12.xml` and `*-coverage-report-py3.12`). This affects both the creation and uploading of artifacts in `.github/actions/build-and-test-branch/action.yml`. [[1]](diffhunk://#diff-8657e2111594bed82a89d5e558e827e566ece1c1f7f813c113cc0b53474eefbaL75-R75) [[2]](diffhunk://#diff-8657e2111594bed82a89d5e558e827e566ece1c1f7f813c113cc0b53474eefbaL97-R113)

**Workflow environment and artifact usage:**

* Set the `PYTHON_VERSION` environment variable to `'3.12'` in the `check_frontend_coverage` and `check_python_coverage` jobs in `.github/workflows/main.yml`, and updated all relevant artifact downloads, file references, and coverage extraction commands to use the new versioned names and paths. [[1]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R96-R97) [[2]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L108-R116) [[3]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L163-R170) [[4]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L179-R181) [[5]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R243-R244) [[6]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L253-R270)