### PR TITLE
Increment version number in pyproject and settings to 1.0.3

### DIFF
--- a/mariner_app/settings.py
+++ b/mariner_app/settings.py
@@ -14,7 +14,7 @@ except ImportError:
     pass
 
 APP_NAME = "mariner_app"
-APP_VERSION = semantic_version.Version(major=1, minor=0, patch=1)
+APP_VERSION = semantic_version.Version(major=1, minor=0, patch=3)
 APP_ROOT = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
 
 WEBPACK_LOADER = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ requires-python = ">=3.10"
 dependencies = [
     "arches>=7.6.17,<8.0.0",
 ]
-version = "1.0.1"
+version = "1.0.3"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
This pull request updates the application version from 1.0.1 to 1.0.3 in both the `mariner_app/settings.py` and `pyproject.toml` files for the next version

Version updates:

* Bumped `APP_VERSION` in `mariner_app/settings.py` from 1.0.1 to 1.0.3.
* Updated the `version` field in `pyproject.toml` from 1.0.1 to 1.0.3.

